### PR TITLE
Add linux-arm-64 release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build for Multiple Platforms
         run: |
           mkdir -p releases
-          PLATFORMS=("windows/amd64" "linux/amd64" "darwin/amd64" "darwin/arm64")
+          PLATFORMS=("windows/amd64" "linux/amd64" "linux/arm64" "darwin/amd64" "darwin/arm64")
           for platform in "${PLATFORMS[@]}"; do
             OS=${platform%/*}
             ARCH=${platform#*/}


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/release.yml` file to update the platforms for which the project is built. The most important change is the addition of the `linux/arm64` platform to the build process.

Platform updates:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L33-R33): Added `linux/arm64` to the list of platforms for the build process.